### PR TITLE
Make example node.js Dockerfile more declarative

### DIFF
--- a/examples/nodejs/Dockerfile
+++ b/examples/nodejs/Dockerfile
@@ -2,6 +2,8 @@ FROM node:10.17.0 AS build-env
 ADD . /app
 WORKDIR /app
 
+RUN npm install
+
 FROM gcr.io/distroless/nodejs
 COPY --from=build-env /app /app
 WORKDIR /app


### PR DESCRIPTION
Include dependency install in node.js example Dockerfile to make need of multistage build more clear.